### PR TITLE
fix: don't panic in findErrorRootNode if traceFiles is empty

### DIFF
--- a/pkg/convert/transform/transform.go
+++ b/pkg/convert/transform/transform.go
@@ -200,6 +200,9 @@ func (t *DefaultTransform) stepInTrace(node Node, traceFiles []TraceFile) bool {
 }
 
 func (t *DefaultTransform) findErrorRootNode(nodes []Node, traceFiles []TraceFile) (errNode Node) {
+	if len(traceFiles) == 0 {
+		return
+	}
 	lastTraceFile := traceFiles[len(traceFiles)-1]
 	for _, node := range nodes {
 		if node.BeginEvent.CodeLocation.FileName == lastTraceFile.FileName &&


### PR DESCRIPTION
Not sure why `traceFiles` are empty, but when it happens lets not panic:
```
  [PANICKED] Test Panicked
  In [ReportAfterSuite] at: /opt/hostedtoolcache/go/1.25.3/x64/src/runtime/panic.go:115 @ 11/20/25 21:26:16.799
  runtime error: index out of range [-1]
  Full Stack Trace
    github.com/Moon1706/ginkgo2allure/pkg/convert/transform.(*DefaultTransform).findErrorRootNode(...)
    	/home/runner/go/pkg/mod/github.com/!moon1706/ginkgo2allure@v0.3.0/pkg/convert/transform/transform.go:203
    github.com/Moon1706/ginkgo2allure/pkg/convert/transform.(*DefaultTransform).findErrorNode(_, {_, _, _}, {{0x2520d02, 0x43}, {{0x306097e, 0x47}, 0x79, {0x0, ...}, ...}, ...})
    	/home/runner/go/pkg/mod/github.com/!moon1706/ginkgo2allure@v0.3.0/pkg/convert/transform/transform.go:172 +0x32c
    github.com/Moon1706/ginkgo2allure/pkg/convert/transform.(*DefaultTransform).AnalyzeEvents(_, {_, _, _}, {{0x2520d02, 0x43}, {{0x306097e, 0x47}, 0x79, {0x0, ...}, ...}, ...})
    	/home/runner/go/pkg/mod/github.com/!moon1706/ginkgo2allure@v0.3.0/pkg/convert/transform/transform.go:72 +0xdb
    github.com/Moon1706/ginkgo2allure/pkg/convert/parser.(*Parser).GetAllureReport(_)
    	/home/runner/go/pkg/mod/github.com/!moon1706/ginkgo2allure@v0.3.0/pkg/convert/parser/parser.go:52 +0xc3
    github.com/Moon1706/ginkgo2allure/pkg/convert.GinkgoToAllureReport({0xc00089d8a0?, 0x1?, 0x1?}, 0x2637e00, {{0x0, 0x0, 0x0}, {0xc0003f0d40, 0x2, 0x2}, ...})
    	/home/runner/go/pkg/mod/github.com/!moon1706/ginkgo2allure@v0.3.0/pkg/convert/convert.go:25 +0x2dc
```